### PR TITLE
fix: Capitalize the `for` word

### DIFF
--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -22,9 +22,9 @@ let { metaTitle } = Astro.props;
       <img src="/assets/logo.png" alt="DevProtocol" class="max-h-8">
     </a>
     <main>
-      <a href="/creators" class="mx-4 font-mono">for Creators</a>
-      <a href="/patrons" class="mx-4 font-mono">for Patrons</a>
-      <a href="/developers" class="mx-4 font-mono">for Developers</a>
+      <a href="/creators" class="mx-4 font-mono">For creators</a>
+      <a href="/patrons" class="mx-4 font-mono">For patrons</a>
+      <a href="/developers" class="mx-4 font-mono">For developers</a>
     </main>
     <a class="border-2 border-gray-900 rounded-lg py-2 px-4">
       <button class="font-mono">Join</button>


### PR DESCRIPTION
Things added/changed:

- Capitalize the `for` word.
