### PR TITLE
[FIX]: Removed unnecessary padding in logo when in mobile view

### DIFF
--- a/src/components/Global/Navbar.vue
+++ b/src/components/Global/Navbar.vue
@@ -22,7 +22,7 @@
       "
     >
       <!-- Dev Protocol Icon -->
-      <a href="https://devprotocol.xyz" class="text-gray-900 p-4">
+      <a href="https://devprotocol.xyz" class="text-gray-900 md:p-4 py-4">
         <svg
           width="224"
           height="38.4"
@@ -94,7 +94,7 @@
         <div class="flex flex-col space-y-3 burger:space-y-0 burger:flex-row space-x-3">
           <!-- Overview Section -->
           <div class="relative">
-            <!-- Main Button with dropdown arrow 
+            <!-- Main Button with dropdown arrow
           On Click - when current dropdown needs to be opened change all other states to false-->
             <button
               @click="
@@ -111,7 +111,7 @@
                 class="dropdown-arrow"
               />
             </button>
-            <!-- Background for the subnavbar 
+            <!-- Background for the subnavbar
           So Clicking outside the navbar will close it -->
             <button
               v-if="isOpen[0]"
@@ -133,7 +133,7 @@
           </div>
           <!-- DAO Section -->
           <div class="relative">
-            <!-- Main Button with dropdown arrow 
+            <!-- Main Button with dropdown arrow
           On Click - when current dropdown needs to be opened change all other states to false-->
             <button
               @click="
@@ -150,7 +150,7 @@
                 class="dropdown-arrow"
               />
             </button>
-            <!-- Background for the subnavbar 
+            <!-- Background for the subnavbar
           So Clicking outside the navbar will close it -->
             <button
               v-if="isOpen[1]"
@@ -166,7 +166,7 @@
           </div>
           <!-- Community Section -->
           <div class="relative">
-            <!-- Main Button with dropdown arrow 
+            <!-- Main Button with dropdown arrow
           On Click - when current dropdown needs to be opened change all other states to false-->
             <button
               @click="
@@ -183,7 +183,7 @@
                 class="dropdown-arrow"
               />
             </button>
-            <!-- Background for the subnavbar 
+            <!-- Background for the subnavbar
           So Clicking outside the navbar will close it -->
             <button
               v-if="isOpen[2]"
@@ -209,7 +209,7 @@
           </div>
           <!-- Help Section -->
           <div class="relative">
-            <!-- Main Button with dropdown arrow 
+            <!-- Main Button with dropdown arrow
           On Click - when current dropdown needs to be opened change all other states to false-->
             <button
               @click="
@@ -226,7 +226,7 @@
                 class="dropdown-arrow"
               />
             </button>
-            <!-- Background for the subnavbar 
+            <!-- Background for the subnavbar
           So Clicking outside the navbar will close it -->
             <button
               v-if="isOpen[3]"


### PR DESCRIPTION
#### Description of the change
- Removed unnecessary horizontal padding in logo when in mobile view
- Note that the UI will still wrap if the screen width gets very small *(<352)*. I believe that most mobile device is greater than this width so there should be nothing to worry about. *If we need to support even smaller device we might need to shrink the logo.*
- fixes #179
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/web3community/devprotocol.xyz/blob/main/CONTRIBUTING.md
-->

<!-- If it fixes an issue, please add Closes #issue_no below with its respective issue number -->

#### Screenshots

<!-- Please add screenshots if applicable. Otherwise, remove this section -->
Current design:
![image](https://user-images.githubusercontent.com/28738855/144608684-802dfc9a-4f35-459f-bd4e-670c9d1404ec.png)

Proposed changes:
![image](https://user-images.githubusercontent.com/28738855/144608755-b328798b-206f-41d8-939e-4d53c1a26026.png)


#### Checklist

**I agree to the following :-**

* [x]   Added description of the change
* [x]   I've read the [contributing guidelines](https://github.com/web3community/devprotocol.xyz/blob/main/CONTRIBUTING.md)
* [x]   Search previous suggestions before making a new PR, as yours may be a duplicate.
* [x]   I acknowledge that all my contributions will be made under the project's license.

Notes (**optional**): <!-- Please add a one-line description for developers or pull request viewers -->


<a href="https://gitpod.io/#https://github.com/web3community/devprotocol.xyz/pull/184"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

